### PR TITLE
Improving filtering for hephaestus

### DIFF
--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunClient.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunClient.cfc
@@ -51,7 +51,7 @@ limitations under the License.
 			var messageContent = "";
 			var jSONData = "";
 			var postResult = "";
-            var doClean = false;
+            		var doClean = false;
 
 			// PR10: In CF10+, the passed in issueDataStruct is not editable in all cases anymore. It looks like a
 			// struct, but is of a different internal data type behind the scenes. This works around that issue.
@@ -67,7 +67,7 @@ limitations under the License.
 				throw("API integration not valid, cannot send message to Raygun");
 			}
 
-            if (isObject(variables.contentFilter) && isArray(arguments.contentFilter) && arraylen(arguments.contentFilter) > 0)
+            if (isObject(variables.contentFilter) && isArray(variables.contentFilter) && arraylen(variables.contentFilter) > 0)
             {
                 applyFilter(variables.contentFilter);
                 doClean = true;
@@ -106,7 +106,7 @@ limitations under the License.
             jSONData = ReplaceNoCase(trim(jSONData), "//[", "[");
 
             if(doClean) {
-                jSONData = applyFilterJson(arguments.contentFilter, jSONData);
+                jSONData = applyFilterJson(variables.contentFilter, jSONData);
             }
         </cfscript>
 

--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunClient.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunClient.cfc
@@ -51,7 +51,6 @@ limitations under the License.
 			var messageContent = "";
 			var jSONData = "";
 			var postResult = "";
-            		var doClean = false;
 
 			// PR10: In CF10+, the passed in issueDataStruct is not editable in all cases anymore. It looks like a
 			// struct, but is of a different internal data type behind the scenes. This works around that issue.
@@ -67,10 +66,9 @@ limitations under the License.
 				throw("API integration not valid, cannot send message to Raygun");
 			}
 
-            if (isObject(variables.contentFilter) && isArray(variables.contentFilter) && arraylen(variables.contentFilter) > 0)
+            if (isObject(variables.contentFilter))
             {
                 applyFilter(variables.contentFilter);
-                doClean = true;
             }
 
             // deal with custom data passed as an argument
@@ -105,7 +103,7 @@ limitations under the License.
             jSONData = ReplaceNoCase(trim(jSONData), "//{", "{");
             jSONData = ReplaceNoCase(trim(jSONData), "//[", "[");
 
-            if(doClean) {
+            if(isObject(variables.contentFilter)) {
                 jSONData = applyFilterJson(variables.contentFilter, jSONData);
             }
         </cfscript>


### PR DESCRIPTION
## What:

For hephaestus we need to apply some filtering to hide things like passwords and PANs from raygun. Currently the filtering done here doesn't actually clean for example the request data, so this change is designed to fix that.

@AntonTutuka @ewanmttk please review