### PR TITLE
Added to the Raygun message an extra attribute, groupingKey, in case it's present in the data struct

### DIFF
--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunMessageDetails.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunMessageDetails.cfc
@@ -44,7 +44,12 @@ limitations under the License.
             catch (any e)
             {
                 returnContent["machineName"] = CGI.SERVER_NAME;
-            }
+			}
+
+			if (structKeyExists(arguments.issueDataStruct,"groupingKey"))
+			{
+				returnContent["groupingKey"] = arguments.issueDataStruct.groupingKey;
+			}
 
 			returnContent["error"] = messageErrorDetails.build(arguments.issueDataStruct);
 			returnContent["request"] = messageRequestDetails.build(arguments.issueDataStruct);

--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunMessageDetails.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunMessageDetails.cfc
@@ -44,7 +44,7 @@ limitations under the License.
             catch (any e)
             {
                 returnContent["machineName"] = CGI.SERVER_NAME;
-			}
+            }
 
 			if (structKeyExists(arguments.issueDataStruct,"groupingKey"))
 			{


### PR DESCRIPTION
**The problem:**

We get this kind of errors
![image](https://user-images.githubusercontent.com/7486120/50977796-b3f47500-14fb-11e9-8537-73f2ebb72448.png)

And when you click on it, you discover it's a different URL that's causing the problem:
![image](https://user-images.githubusercontent.com/7486120/50977856-ccfd2600-14fb-11e9-90b7-b3ef6e066b0a.png)

That is because Raygun is grouping errors based, mainly, on the stacktrace. So in our case, all shadow calls go through more or less the same path:

![image](https://user-images.githubusercontent.com/7486120/50977931-f7e77a00-14fb-11e9-8c3e-c76a71b2fc72.png)

So if there's 2 different URLs that use the same Shadow version, Raygun will group any errors together.

**The solution:**

Raygun came up with a solution, by allowing clients to use a _grouping key_ : https://raygun.com/blog/custom-error-grouping/
The functionality is available for most major framework libraries, but of course it's not there in the library we're using https://github.com/MindscapeHQ/raygun4cfml .

Fortunately, raygun's api is pretty simple (REST api https://raygun.com/docs/integrations/api ) and `raygun4cfml` is straightforward enough so it allows us to add an extra argument to the JSON that it sends to Raygun's API through http: `groupingKey`.

![image](https://user-images.githubusercontent.com/7486120/50978386-f66a8180-14fc-11e9-8238-8f718e86fac8.png)


Their recommendation for the grouping key is to make it a hash (MD5 or anything else) of the stacktrace at least. To fix our issue, I also added to the stacktrace the URL that was targeted by the `shadowxmlrpcclient` component. 

**Related PRs:**

https://github.com/tutuka/VoucherEngine/pull/3247
https://github.com/tutuka/Components/pull/354