### PR TITLE
DEV-5872 - Fix error in Raygun lib

### DIFF
--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
@@ -107,6 +107,7 @@ limitations under the License.
 				tagContextData[j]["lineNumber"] = (structKeyExists(arguments.issueDataStruct.tagcontext[j],"line")) ?
 					trim(arguments.issueDataStruct.tagcontext[j]["line"]) : "";
 			}
+
 			returnContent["stackTrace"] = tagContextData;
 
 			return returnContent;

--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
@@ -100,11 +100,13 @@ limitations under the License.
 			{
 				tagContextData[j] = {};
 				tagContextData[j]["methodName"] = "";
-				tagContextData[j]["className"] = trim( arguments.issueDataStruct.tagcontext[j]["id"] );
-				tagContextData[j]["fileName"] = trim( arguments.issueDataStruct.tagcontext[j]["template"] );
-				tagContextData[j]["lineNumber"] = trim( arguments.issueDataStruct.tagcontext[j]["line"] );
+				tagContextData[j]["className"] = (structKeyExists(arguments.issueDataStruct.tagcontext[j],"id")) ?
+					trim(arguments.issueDataStruct.tagcontext[j]["id"]) : "";
+				tagContextData[j]["fileName"] = (structKeyExists(arguments.issueDataStruct.tagcontext[j],"template")) ?
+					trim(arguments.issueDataStruct.tagcontext[j]["template"]) : "";
+				tagContextData[j]["lineNumber"] = (structKeyExists(arguments.issueDataStruct.tagcontext[j],"line")) ?
+					trim(arguments.issueDataStruct.tagcontext[j]["line"]) : "";
 			}
-
 			returnContent["stackTrace"] = tagContextData;
 
 			return returnContent;


### PR DESCRIPTION
To fix this error: 

> Detail: [empty string]
ErrNumber: 0
Message: Element ID is undefined in a Java object of type class coldfusion.util.FastHashtable.
Resolvedname: [empty string]
StackTrace: coldfusion.runtime.UndefinedElementException: Element ID is undefined in a Java object of type class coldfusion.util.FastHashtable.
	at coldfusion.runtime.CfJspPage.ArrayGetAt(CfJspPage.java:1387)
	at coldfusion.runtime.CfJspPage._arrayGetAt(CfJspPage.java:1603)
	at coldfusion.runtime.CfJspPage._arrayGetAt(CfJspPage.java:1598)
	at coldfusion.runtime.CfJspPage._arrayGetAt(CfJspPage.java:975)
	at coldfusion.runtime.CfJspPage._arrayGetAt(CfJspPage.java:957)
	at cfRaygunExceptionMessage2ecfc1912025334$funcBUILD.runFunction(E:\WWW\Development\Components\raygun4cfml\src\nz\co\ventego-creative\raygun4cfml\RaygunExceptionMessage.cfc:103)
	at coldfusion.runtime.UDFMethod.invoke(UDFMethod.java:553)
	at coldfusion.filter.SilentFilter.invoke(SilentFilter.java:47)
	at coldfusion.runtime.UDFMethod$ReturnTypeFilter.invoke(UDFMethod.java:484)
	at coldfusion.runtime.UDFMethod$ArgumentCollectionFilter.invoke(UDFMethod.java:447)
	at coldfusion.filter.FunctionAccessFilter.invoke(FunctionAccessFilter.java:95)
	at coldfusion.runtime.UDFMethod.runFilterChain(UDFMethod.java:398)
	at coldfusion.runtime.UDFMethod.runFilterChain(UDFMethod.java:371)
	at coldfusion.runtime.UDFMethod.invoke(UDFMethod.java:287)


It's at least one of the reasons that make some errors be in buglog and not in raygun, there might be others and for that: 
https://github.com/tutuka/components/pull/545